### PR TITLE
fix: update CI pipeline from Bun to PNPM + Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,30 +2,36 @@ name: "CI"
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main]
   pull_request:
-    branches: [ develop ]
+    branches: [main]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 🛎
+      - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install bun 🍔
-        uses: oven-sh/setup-bun@v2
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
-      - name: Install dependencies 📦
-        run: bun install
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
 
-      - name: Lint source code ✨
-        run: bun run lint
+      - name: Install dependencies
+        run: pnpm install
 
-      - name: Run tests 🧪
-        run: bun run test:coverage
+      - name: Lint source code
+        run: pnpm run lint
+
+      - name: Run tests
+        run: pnpm run test:coverage
         env:
           CI: true
 
-      - name: Build 🏗
-        run: bun run build
+      - name: Build
+        run: pnpm run build


### PR DESCRIPTION
## Summary
- Replace Bun with PNPM + Node 24 LTS in CI workflow
- Fix PR trigger to target `main` instead of non-existent `develop` branch
- Add pnpm caching for faster CI runs

## Test plan
- [ ] CI pipeline runs successfully on this PR
- [ ] Lint, test, and build steps all pass

Closes #1