### PR TITLE
fix: show correct max length in vString error message

### DIFF
--- a/src/schemas/__tests__/recipe.schema.spec.ts
+++ b/src/schemas/__tests__/recipe.schema.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 
 import type { RecipeObject } from "~/types/recipe.interface";
 
+import { vString } from "../common.schema";
 import {
 	IngredientGroupSchema,
 	IngredientItemSchema,
@@ -526,6 +527,24 @@ describe("RecipeObjectSchema", () => {
 			links: [{ href: "not-a-url", text: "Invalid" }],
 		};
 		expect(() => v.parse(RecipeObjectSchema, recipe)).toThrow();
+	});
+});
+
+describe("vString", () => {
+	it("should show correct max length in error message when using default", () => {
+		const schema = vString("Test");
+		const longString = "a".repeat(6000);
+		expect(() => v.parse(schema, longString)).toThrow(
+			"Test must be less than 5000 characters",
+		);
+	});
+
+	it("should show correct max length in error message when max is specified", () => {
+		const schema = vString("Title", { max: 500 });
+		const longString = "a".repeat(501);
+		expect(() => v.parse(schema, longString)).toThrow(
+			"Title must be less than 500 characters",
+		);
 	});
 });
 

--- a/src/schemas/common.schema.ts
+++ b/src/schemas/common.schema.ts
@@ -7,16 +7,15 @@ const HOSTNAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9.-]*\.[a-zA-Z]{2,}$/;
 /**
  * Helper to create a required, non-empty string field
  */
-export const vString = (fieldName: string, { min = 1, max = 0 } = {}) =>
-	v.pipe(
+export const vString = (fieldName: string, { min = 1, max = 0 } = {}) => {
+	const resolvedMax = max > 0 ? max : MAX_STRING_LENGTH;
+	return v.pipe(
 		v.string(`${fieldName} must be a string`),
 		v.minLength(min, `${fieldName} cannot be empty`),
-		v.maxLength(
-			max > 0 ? max : MAX_STRING_LENGTH,
-			`${fieldName} must be less than ${max} characters`,
-		),
+		v.maxLength(resolvedMax, `${fieldName} must be less than ${resolvedMax} characters`),
 		v.transform((s) => s.trim()),
 	);
+};
 
 /**
  * Helper to create a URL string field


### PR DESCRIPTION
## Summary
- Fix `vString()` error message that displayed "must be less than 0 characters" when using the default max length
- Resolve the max value before interpolating into the error message string
- Add tests for error message correctness with both default and explicit max

## Test plan
- [x] `pnpm test` — all 445 tests pass (2 new)
- [x] Verify error message says "5000" not "0" for default max

Closes #14