### PR TITLE
fix: avoid mutating input object in applyRecipeValidations transform

### DIFF
--- a/src/schemas/__tests__/recipe.schema.spec.ts
+++ b/src/schemas/__tests__/recipe.schema.spec.ts
@@ -456,6 +456,18 @@ describe("RecipeObjectSchema", () => {
 		expect(result.totalTime).toBe(50);
 	});
 
+	it("should not mutate the input object when auto-calculating totalTime", () => {
+		const recipe = {
+			...validRecipe,
+			totalTime: null,
+			cookTime: 20,
+			prepTime: 15,
+		};
+		const result = v.parse(RecipeObjectSchema, recipe);
+		expect(result.totalTime).toBe(35);
+		expect(recipe.totalTime).toBeNull();
+	});
+
 	it("should skip totalTime validation when any time is null", () => {
 		const recipe = {
 			...validRecipe,

--- a/src/schemas/recipe.schema.ts
+++ b/src/schemas/recipe.schema.ts
@@ -186,7 +186,7 @@ export function applyRecipeValidations(schema: v.GenericSchema<unknown, RecipeOb
 		v.transform((data) => {
 			// Auto-fix: calculate totalTime if missing but cook and prep times exist
 			if (!data.totalTime && !isNull(data.cookTime) && !isNull(data.prepTime)) {
-				data.totalTime = data.cookTime + data.prepTime;
+				return { ...data, totalTime: data.cookTime + data.prepTime };
 			}
 			return data;
 		}),


### PR DESCRIPTION
## Summary
- Fix `v.transform()` in `applyRecipeValidations` that mutated the input object's `totalTime` field in-place
- Return a new object with spread (`{ ...data, totalTime }`) instead of direct assignment
- Add test verifying the original input is not mutated after `parse()`

## Test plan
- [x] `pnpm test` — all 444 tests pass (1 new)
- [x] New test confirms `recipe.totalTime` remains `null` after parsing

Closes #13