### PR TITLE
refactor: narrow public API surface with explicit exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,31 @@
 import { scrapers } from "./scrapers/_index";
 import { getHostName } from "./utils";
 
-export * from "~/schemas/recipe.schema";
-export * from "~/types/recipe.interface";
-export * from "~/types/scraper.interface";
-
-export * from "./abstract-extractor-plugin";
-export * from "./abstract-postprocessor-plugin";
-export * from "./logger";
+// Public API
 export { scrapers };
+
+// Schema & validation
+export { RECIPE_SCHEMA_VERSION, RecipeObjectSchema } from "~/schemas/recipe.schema";
+// Types
+export type {
+	IngredientGroup,
+	IngredientItem,
+	Ingredients,
+	InstructionGroup,
+	InstructionItem,
+	Instructions,
+	Link,
+	RecipeData,
+	RecipeFields,
+	RecipeObject,
+} from "~/types/recipe.interface";
+export type { ScraperOptions } from "~/types/scraper.interface";
+
+export { ExtractorPlugin } from "./abstract-extractor-plugin";
+export { PostProcessorPlugin } from "./abstract-postprocessor-plugin";
+// Extension points
+export { AbstractScraper } from "./abstract-scraper";
+export { LogLevel } from "./logger";
 
 /**
  * Returns a scraper class for the given URL, if implemented.


### PR DESCRIPTION
## Summary

Closes #15

Replaces wildcard `export *` re-exports in `src/index.ts` with explicit named exports. This prevents internal implementation details from leaking into the public API.

### Removed from public API
- `Logger` class (internal utility)
- `List` type alias (`Set<string>` — internal representation)
- `ParsedIngredient` type (internal schema inference)
- `OptionalRecipeFields` type (internal bookkeeping)
- `applyRecipeValidations()` function (schema internals)
- Individual sub-schemas (`IngredientItemSchema`, `InstructionGroupSchema`, etc.)

### Kept in public API
- `getScraper()`, `scrapers` — core entry points
- `AbstractScraper`, `ExtractorPlugin`, `PostProcessorPlugin` — extension points
- `LogLevel` — needed for `ScraperOptions`
- `RecipeObjectSchema`, `RECIPE_SCHEMA_VERSION` — validation
- All consumer-facing types: `RecipeObject`, `RecipeData`, `RecipeFields`, `IngredientGroup`, `InstructionGroup`, `Link`, `ScraperOptions`, etc.

## Test plan

- [x] TypeScript compiles without errors
- [x] All 443 tests pass
- [x] Biome lint clean