### PR TITLE
chore: add proper tsdown config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"cooking"
 	],
 	"scripts": {
-		"build": "tsdown src/index.ts --outdir dist",
+		"build": "tsdown",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"test:coverage": "vitest run --coverage",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,8 +1,17 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-	entry: ["./src/index.ts"],
+	entry: ["src/index.ts"],
+	outDir: "dist",
+	format: "esm",
 	dts: true,
-	format: ["esm"],
 	sourcemap: true,
+	clean: true,
+	external: [
+		"node-html-parser",
+		"valibot",
+		"tinyduration",
+		"parse-ingredient",
+		"jsonrepair",
+	],
 });


### PR DESCRIPTION
## Summary

Closes #19

Adds a proper `tsdown.config.ts` with:
- `outDir: "dist"` — explicit output directory
- `clean: true` — clean output before build
- `external` — all 5 runtime dependencies (node-html-parser, valibot, tinyduration, parse-ingredient, jsonrepair) are excluded from the bundle

Simplifies the build script from `tsdown src/index.ts --outdir dist` to just `tsdown`.

## Test plan

- [x] `pnpm run build` succeeds (63 kB bundle)
- [x] `dist/index.mjs` contains `import` statements for all external packages (not bundled)
- [x] `dist/index.d.mts` type declarations generated
- [x] Source maps generated