### PR TITLE
fix: misc improvements (links, lazy init, entity decoding)

### DIFF
--- a/src/__tests__/abstract-scraper.spec.ts
+++ b/src/__tests__/abstract-scraper.spec.ts
@@ -89,9 +89,9 @@ describe("AbstractScraper utility methods", () => {
       <a href="/local">Local</a>
       <a>No href</a>
     `;
-		it("returns undefined when linksEnabled is false", () => {
+		it("returns empty array when linksEnabled is false", () => {
 			scraper = new DummyScraper(html, "url", { linksEnabled: false });
-			expect(scraper.links()).toBeUndefined();
+			expect(scraper.links()).toEqual([]);
 		});
 
 		it("returns only absolute links when linksEnabled is true", () => {

--- a/src/abstract-scraper.ts
+++ b/src/abstract-scraper.ts
@@ -142,7 +142,7 @@ export abstract class AbstractScraper {
 
 	links(): RecipeFields["links"] {
 		if (!this.options.linksEnabled) {
-			return undefined;
+			return [];
 		}
 
 		return this.$.querySelectorAll("a[href]")
@@ -208,6 +208,7 @@ export abstract class AbstractScraper {
 			dietaryRestrictions,
 			equipment,
 			keywords,
+			links,
 			nutrients,
 			reviews,
 			...rest
@@ -220,6 +221,7 @@ export abstract class AbstractScraper {
 			dietaryRestrictions: Array.from(dietaryRestrictions),
 			equipment: Array.from(equipment),
 			keywords: Array.from(keywords),
+			...(links && links.length > 0 ? { links } : {}),
 			nutrients: Object.fromEntries(nutrients),
 			reviews: Object.fromEntries(reviews),
 		};

--- a/src/plugins/schema-org.extractor/index.ts
+++ b/src/plugins/schema-org.extractor/index.ts
@@ -79,13 +79,21 @@ export class SchemaOrgPlugin extends ExtractorPlugin {
 		dietaryRestrictions: this.dietaryRestrictions.bind(this),
 	};
 
+	private initialized = false;
+
 	constructor($: HTMLElement, logLevel?: LogLevel) {
 		super($);
-
 		this.logger = new Logger(SchemaOrgPlugin.name, logLevel);
+	}
+
+	private ensureInitialized() {
+		if (this.initialized) {
+			return;
+		}
 		this.extractJsonLdData();
 		this.extractMicrodataData();
 		this.processSchemaData();
+		this.initialized = true;
 	}
 
 	supports(field: keyof RecipeFields): boolean {
@@ -93,6 +101,7 @@ export class SchemaOrgPlugin extends ExtractorPlugin {
 	}
 
 	extract<Key extends keyof RecipeFields>(field: Key): RecipeFields[Key] {
+		this.ensureInitialized();
 		const extractor = this.extractors[field];
 
 		if (!isFunction(extractor)) {


### PR DESCRIPTION
## Summary

Closes #20

Addresses the 4 sub-issues from #20:

### 1. `links()` returns `[]` instead of `undefined` when disabled
- `links()` now returns `[]` instead of `undefined` when `linksEnabled` is false
- `toRecipeObject()` omits the `links` field when empty for backward compatibility with existing fixture data

### 2. SchemaOrgPlugin lazy initialization
- Moved `extractJsonLdData()`, `extractMicrodataData()`, and `processSchemaData()` out of the constructor
- Now called lazily on first `extract()` call via `ensureInitialized()`
- Prevents constructor side-effects and inconsistent state if parsing throws

### 3. Entity decoding — already handled
- `HtmlStripperPlugin` already has tests for entity decoding (`&amp;`, `&#x27;`, `&egrave;`, `&nbsp;`, `&deg;`, etc.)
- All tests pass, no regression found

### 4. Rate limiting in fetch-test-data — already handled
- Script already has 250ms delay between batches of 10 (line 128-130)

## Test plan

- [x] Updated test: `links()` returns `[]` when disabled (was `undefined`)
- [x] All 443 tests pass
- [x] TypeScript compiles without errors